### PR TITLE
Compile support for AMD and CommonJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ grunt.initConfig({
 * concat: `Boolean`
 	* you can concat multiple tag file to a single file 
 	* default : `false`
+* modular: `Boolean`
+	* AMD and CommonJS
+	* default : `false`
 
 if you want use typescript , coffee or es , you should install compile module
 


### PR DESCRIPTION
The RiotJS library supports AMD and CommonJS, yet the grunt compiler plugin does not when converting .tag files into .js files.

The result of this is that when using RequireJS or Browserify the browser tries to execute `riot.tag()` and the `riot` object is undefined since it has not been bound to the `window` object.

This commit provides a boolean `modular` option to incorporate these standards into the out JS tag file/s.
