### PR TITLE
support for es6 modularization and exporting of tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-riot",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "riot custom tag compile grunt plugin.",
   "repository": "https://github.com/ariesjia/grunt-riot",
   "author": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "concat-stream": "^1.4.7",
-    "modularize": "^0.1.5",
+    "modularize": "^0.1.7",
     "riot": "^2.3"
   }
 }

--- a/tasks/riot.js
+++ b/tasks/riot.js
@@ -78,6 +78,15 @@ module.exports = function (grunt) {
 					modularConfig.deps.unshift('riot');
 				}
 
+				if (modularConfig.exports) {
+					if (options.concat) {
+						grunt.log.warn('Cannot export "' + modularConfig.exports + '" if concat option is enabled.');
+					}
+					else {
+						source = 'var ' + modularConfig.exports + ' = ' + source;
+					}
+				}
+
 				modularConfig.input = source;
 
 				return modularize(modularConfig);


### PR DESCRIPTION
I have a use case where I need to export the tag (generated by `riot.tag2()`), this simply gives the tag instance a name and returns / exports it by enabling the following options flag:

``` js
{
  modular: { 
    exports: 'MyTagName' 
  }
}
```

It obviously is not compatible with the `concat` flag as it can only export 1 tag.

I have also updated to modularize v0.1.7 which supports es6 module exports.
